### PR TITLE
Fix missing "type": "command" in statusLine settings

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -235,6 +235,7 @@ func SetStatuslineCommand(settings Settings, command string) {
 	if !ok {
 		// No statusLine object exists, create one
 		settings[StatusLineKey] = map[string]any{
+			"type":    "command",
 			"command": command,
 		}
 		return
@@ -245,12 +246,14 @@ func SetStatuslineCommand(settings Settings, command string) {
 	if !ok {
 		// statusLine exists but is not a map, replace it
 		settings[StatusLineKey] = map[string]any{
+			"type":    "command",
 			"command": command,
 		}
 		return
 	}
 
-	// Update only the command field, preserving other fields
+	// Update the type and command fields, preserving other fields
+	statuslineMap["type"] = "command"
 	statuslineMap["command"] = command
 }
 
@@ -269,8 +272,9 @@ func RemoveStatusline(settings Settings) {
 		return
 	}
 
-	// Remove only the command key
+	// Remove the command and type keys
 	delete(statuslineMap, "command")
+	delete(statuslineMap, "type")
 
 	// If statusLine object is now empty, remove it entirely
 	if len(statuslineMap) == 0 {


### PR DESCRIPTION
## Summary
- `SetStatuslineCommand` was only writing `"command"` but not the required `"type": "command"` field, producing invalid `settings.json` that prevents Claude Code from starting
- Also updated `RemoveStatusline` to clean up the `"type"` field when removing the statusLine config

Fixes #4