### PR TITLE
Cache API responses to avoid 429 rate limiting

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -248,6 +248,7 @@ func checkAPIEndpoint() checkResult {
 
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("anthropic-beta", "oauth-2025-04-20")
+	req.Header.Set("User-Agent", "claude-code")
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/statusline/cache.go
+++ b/internal/statusline/cache.go
@@ -1,0 +1,91 @@
+package statusline
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	cacheFile   = "ccstatus-cache.json"
+	defaultTTL  = 5 * time.Minute
+)
+
+type cachedUsage struct {
+	Usage     UsageResponse `json:"usage"`
+	FetchedAt time.Time     `json:"fetched_at"`
+}
+
+func getCachePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", cacheFile), nil
+}
+
+// loadCache returns a cached UsageResponse if it exists and is fresh.
+func loadCache() (*UsageResponse, bool) {
+	path, err := getCachePath()
+	if err != nil {
+		return nil, false
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+
+	var cached cachedUsage
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil, false
+	}
+
+	if time.Since(cached.FetchedAt) > defaultTTL {
+		return nil, false
+	}
+
+	return &cached.Usage, true
+}
+
+// loadCacheIgnoringTTL returns a cached UsageResponse even if expired.
+// Used as a fallback when the API is unavailable.
+func loadCacheIgnoringTTL() (*UsageResponse, bool) {
+	path, err := getCachePath()
+	if err != nil {
+		return nil, false
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+
+	var cached cachedUsage
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil, false
+	}
+
+	return &cached.Usage, true
+}
+
+// saveCache writes a UsageResponse to the cache file.
+func saveCache(usage *UsageResponse) {
+	path, err := getCachePath()
+	if err != nil {
+		return
+	}
+
+	cached := cachedUsage{
+		Usage:     *usage,
+		FetchedAt: time.Now(),
+	}
+
+	data, err := json.Marshal(cached)
+	if err != nil {
+		return
+	}
+
+	_ = os.WriteFile(path, data, 0600)
+}

--- a/internal/statusline/statusline.go
+++ b/internal/statusline/statusline.go
@@ -22,6 +22,7 @@ type Input struct {
 	Model struct {
 		DisplayName string `json:"display_name"`
 	} `json:"model"`
+	Version string `json:"version"`
 }
 
 // Credentials represents the OAuth credentials from Keychain
@@ -54,8 +55,12 @@ func Run() {
 	// Load configuration
 	cfg, _ := config.LoadCCStatusConfig()
 
-	// Read model info from stdin
-	model := readModelFromStdin()
+	// Read input from stdin
+	input := readInput()
+	model := input.Model.DisplayName
+	if model == "" {
+		model = "Unknown"
+	}
 
 	// Get OAuth token from macOS Keychain
 	token, err := GetAccessToken()
@@ -65,7 +70,7 @@ func Run() {
 	}
 
 	// Fetch usage data from Anthropic API (serves from cache if fresh)
-	usage, err := FetchUsage(token)
+	usage, err := FetchUsage(token, input.Version)
 	if err != nil || usage.Error != nil {
 		// API failed — try serving stale cache rather than showing dashes
 		if stale, ok := loadCacheIgnoringTTL(); ok {
@@ -80,22 +85,19 @@ func Run() {
 	printStatusLine(model, usage, cfg)
 }
 
-// readModelFromStdin reads and parses the JSON input from stdin
-func readModelFromStdin() string {
+// readInput reads and parses the JSON input from stdin
+func readInput() Input {
 	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
-		return "Unknown"
+		return Input{}
 	}
 
 	var input Input
 	if err := json.Unmarshal(data, &input); err != nil {
-		return "Unknown"
+		return Input{}
 	}
 
-	if input.Model.DisplayName == "" {
-		return "Unknown"
-	}
-	return input.Model.DisplayName
+	return input
 }
 
 // GetAccessToken retrieves the OAuth token from macOS Keychain
@@ -121,7 +123,7 @@ func GetAccessToken() (string, error) {
 
 // FetchUsage retrieves usage data from the Anthropic API, using a local
 // cache to avoid hitting the API on every statusline refresh.
-func FetchUsage(token string) (*UsageResponse, error) {
+func FetchUsage(token string, ccVersion string) (*UsageResponse, error) {
 	if cached, ok := loadCache(); ok {
 		return cached, nil
 	}
@@ -134,6 +136,11 @@ func FetchUsage(token string) (*UsageResponse, error) {
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("anthropic-beta", "oauth-2025-04-20")
+	if ccVersion != "" {
+		req.Header.Set("User-Agent", "claude-code/"+ccVersion)
+	} else {
+		req.Header.Set("User-Agent", "claude-code")
+	}
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)

--- a/internal/statusline/statusline.go
+++ b/internal/statusline/statusline.go
@@ -64,9 +64,14 @@ func Run() {
 		return
 	}
 
-	// Fetch usage data from Anthropic API
+	// Fetch usage data from Anthropic API (serves from cache if fresh)
 	usage, err := FetchUsage(token)
 	if err != nil || usage.Error != nil {
+		// API failed — try serving stale cache rather than showing dashes
+		if stale, ok := loadCacheIgnoringTTL(); ok {
+			printStatusLine(model, stale, cfg)
+			return
+		}
 		printFallback(model, cfg)
 		return
 	}
@@ -114,8 +119,13 @@ func GetAccessToken() (string, error) {
 	return creds.ClaudeAiOauth.AccessToken, nil
 }
 
-// FetchUsage retrieves usage data from the Anthropic API
+// FetchUsage retrieves usage data from the Anthropic API, using a local
+// cache to avoid hitting the API on every statusline refresh.
 func FetchUsage(token string) (*UsageResponse, error) {
+	if cached, ok := loadCache(); ok {
+		return cached, nil
+	}
+
 	req, err := http.NewRequest("GET", "https://api.anthropic.com/api/oauth/usage", nil)
 	if err != nil {
 		return nil, err
@@ -137,10 +147,16 @@ func FetchUsage(token string) (*UsageResponse, error) {
 		return nil, err
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
 	var usage UsageResponse
 	if err := json.Unmarshal(body, &usage); err != nil {
 		return nil, err
 	}
+
+	saveCache(&usage)
 
 	return &usage, nil
 }


### PR DESCRIPTION
## Summary

Two fixes for the persistent 429 rate limiting (#6):

1. **Send `User-Agent: claude-code/<version>` header** — The Anthropic API applies different rate limit buckets based on User-Agent. Without this header, requests hit a strict bucket that 429s after ~5 calls. The version is read from the JSON that Claude Code pipes via stdin. The `doctor` command also gets this header so its API check passes. (Ref: anthropics/claude-code#30930)

2. **Cache API responses to disk** — Adds a file-based cache (`~/.claude/ccstatus-cache.json`) with a 5-minute TTL. When the cache is fresh, no API call is made. When the API fails, stale cached data is served as a fallback instead of showing `Session: --% | Week: --%`.

Also adds an explicit check for non-200 HTTP status codes, which was previously missing.

Fixes #6